### PR TITLE
Silence touch .hubot_history permission error in live environment

### DIFF
--- a/bin/hubot-common
+++ b/bin/hubot-common
@@ -5,7 +5,8 @@ npm install
 export PATH="node_modules/.bin:$PATH"
 
 # Shell adapter logs an error if .hubot_history doesn't exist yet; pre-create it.
-touch .hubot_history
+# Ignore failures — the directory may not be writable (e.g. Dokku with Telegram adapter).
+touch .hubot_history 2>/dev/null || true
 
 # hubot-telegram reads TELEGRAM_TOKEN; bridge from the canonical env var name
 if [ -n "$HUBOT_TELEGRAM_TOKEN" ] && [ -z "$TELEGRAM_TOKEN" ]; then


### PR DESCRIPTION
Dokku runs the Telegram adapter so .hubot_history is never used, but the touch still ran and failed with EACCES. Make it best-effort.

https://claude.ai/code/session_01R4dQshLZMGvbpmMfjw4PxF