### PR TITLE
Fix Hubot 14 adapter loading: use full package name hubot-telegram

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,2 +1,2 @@
-web: bin/hubot -a telegram
+web: bin/hubot -a hubot-telegram
 console: bin/hubot

--- a/bin/hubot
+++ b/bin/hubot
@@ -8,7 +8,7 @@ set -e
 # Default to the Telegram adapter unless an adapter is already specified or we
 # are running in CI (where no Telegram token is available).
 if [ -z "$CI" ] && ! echo " $* " | grep -q -- ' -a '; then
-  set -- -a telegram "$@"
+  set -- -a hubot-telegram "$@"
 fi
 
 exec node_modules/.bin/hubot --name "ipho_bot" "$@"


### PR DESCRIPTION
Hubot 14 removed the implicit `hubot-` prefix from adapter resolution.
`importFromRepo` now calls `import(adapterName)` literally, so `-a telegram`
tries to import the non-existent package `telegram` instead of `hubot-telegram`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
