### PR TITLE
Fix middleware callback signature for Hubot compatibility

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -51,6 +51,8 @@ jobs:
       run: npm run build --if-present
     - name: Run Tests
       run: npm test
+    - name: Smoke test (adapter startup)
+      run: node bin/smoke-test.mjs
 
   docker:
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Brain storage uses Redis (`hubot-redis-brain`) with S3 fallback (`hubot-s3-brain
 
 | Variable | Description |
 |---|---|
-| `HUBOT_TELEGRAM_TOKEN` | Telegram Bot API token |
+| `TELEGRAM_TOKEN` | Telegram Bot API token (`HUBOT_TELEGRAM_TOKEN` accepted as legacy alias) |
 | `ANTHROPIC_API_KEY` | Anthropic API key (for Claude AI catchall) |
 | `HUBOT_LLM_MODEL` | Claude model to use (default: `claude-haiku-4-5-20251001`) |
 | `HUBOT_LLM_MAX_HISTORY` | Per-user conversation turns to retain (default: `10`) |
@@ -44,11 +44,11 @@ Copy `.env.example` (if present) to `.env` — `dotenv` loads it automatically v
 # Install dependencies
 npm install
 
-# Console adapter (no Telegram needed)
+# Telegram adapter — default when TELEGRAM_TOKEN is set (requires token)
 bin/hubot
 
-# Telegram adapter (requires HUBOT_TELEGRAM_TOKEN)
-bin/hubot -f ./adapters/telegram.mjs
+# Shell/console adapter (no Telegram token needed)
+CI=1 bin/hubot
 ```
 
 Once running, address the bot by name: `ipho_bot help`
@@ -60,6 +60,8 @@ npm test
 ```
 
 This runs `bin/hubot-test.sh` using the `expect` CLI tool. Requires the `HUBOT_S3_BRAIN_ACCESS_KEY_ID` and `HUBOT_S3_BRAIN_SECRET_ACCESS_KEY` env vars (or GitHub Actions secrets) to be set.
+
+CI also runs `bin/smoke-test.mjs` to validate that the Telegram adapter starts cleanly (middleware signatures, class hierarchy).
 
 ## Adding Scripts
 

--- a/adapters/telegram.mjs
+++ b/adapters/telegram.mjs
@@ -143,7 +143,7 @@ class TelegramAdapter extends Adapter {
     this.bot.on('channel_post', this.handleUpdate)
 
     // Register middleware to enrich Response with Telegram API methods
-    this.robot.listenerMiddleware((context, next, done) => {
+    this.robot.listenerMiddleware((context) => {
       const response = context.response
       response.sendMessage = this.bot.sendMessage.bind(this.bot)
       response.sendAnimation = this.bot.sendAnimation.bind(this.bot)
@@ -156,7 +156,6 @@ class TelegramAdapter extends Adapter {
       response.sendVideoNote = this.bot.sendVideoNote.bind(this.bot)
       response.sendVoice = this.bot.sendVoice.bind(this.bot)
       response.sendChatAction = this.bot.sendChatAction.bind(this.bot)
-      next(() => done())
     })
 
     this.robot.logger.info('Telegram Adapter Started...')

--- a/bin/smoke-test.mjs
+++ b/bin/smoke-test.mjs
@@ -1,9 +1,11 @@
 #!/usr/bin/env node
 /**
- * Smoke test: verifies the Telegram adapter can be imported and instantiated
- * as a proper subclass of hubot's Adapter. Catches TypeErrors like:
- *   "Class constructor Adapter cannot be invoked without 'new'"
- * which occur when a CJS adapter uses `_super.call(this)` against an ES6 class.
+ * Smoke test: verifies the Telegram adapter can be imported, instantiated,
+ * and started without runtime errors. Catches:
+ *   - "Class constructor Adapter cannot be invoked without 'new'"
+ *     (CJS adapter using `_super.call(this)` against an ES6 class)
+ *   - "Incorrect number of arguments for middleware callback (expected 1, got N)"
+ *     (old-style (context, next, done) middleware passed to hubot 14+)
  */
 
 import { Adapter } from '../node_modules/hubot/index.mjs'
@@ -17,14 +19,30 @@ const mockRobot = {
   logger: { info: () => {}, debug: () => {}, warning: () => {} },
   on: () => {},
   brain: { userForId: (_id, u) => u },
-  listenerMiddleware: () => {},
+  listenerMiddleware: (fn) => {
+    if (fn.length !== 1) {
+      throw new Error(`Incorrect number of arguments for middleware callback (expected 1, got ${fn.length})`)
+    }
+  },
   name: 'test',
 }
 
+process.env.TELEGRAM_TOKEN = 'test:token'
 const instance = telegramAdapter.use(mockRobot)
 
 if (!(instance instanceof Adapter)) {
   throw new Error('adapter is not an Adapter instance — prototype chain is broken')
 }
+
+// Mock bot API calls to avoid real network requests
+instance.bot.getMe = () => Promise.resolve({ first_name: 'test' })
+instance.bot.startPolling = () => {}
+
+// Call run() to exercise middleware registration and startup path
+await new Promise((resolve, reject) => {
+  instance.on('connected', resolve)
+  instance.on('error', (err) => reject(err))
+  instance.run()
+})
 
 console.log('smoke test passed')


### PR DESCRIPTION
Hubot now requires middleware callbacks to accept exactly 1 argument
(context). Updated listenerMiddleware call to drop the old (context, next, done)
signature and removed the trailing next(() => done()) call.

https://claude.ai/code/session_017kuTGfvWiASz8rhGbAUx9S