### PR TITLE
ci: migrate dokku deploy to Cloudflare tunnel SSH

### DIFF
--- a/.github/workflows/dokku.yml
+++ b/.github/workflows/dokku.yml
@@ -18,10 +18,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Configure SSH for Cloudflare tunnel
+        run: |
+          mkdir -p ~/.ssh
+          cat >> ~/.ssh/config <<'EOF'
+          Host dokku-ssh.iphoting.cc
+            ProxyCommand docker run --rm -i cloudflare/cloudflared:latest access ssh --hostname %h
+            StrictHostKeyChecking no
+          EOF
       - name: Push to dokku
         uses: dokku/github-action@v1.4.0
         with:
           # specify `--force` as a flag for git pushes
           git_push_flags: '--force'
-          git_remote_url: 'ssh://dokku@c.iphoting.cc:3022/iphobot'
+          git_remote_url: 'ssh://dokku@dokku-ssh.iphoting.cc/iphobot'
           ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}

--- a/.github/workflows/dokku.yml
+++ b/.github/workflows/dokku.yml
@@ -18,18 +18,20 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: Configure SSH for Cloudflare tunnel
+      - name: Set up SSH and push to dokku
+        env:
+          SSH_PRIVATE_KEY: ${{ secrets.SSH_PRIVATE_KEY }}
         run: |
           mkdir -p ~/.ssh
+          echo "$SSH_PRIVATE_KEY" > ~/.ssh/id_rsa
+          chmod 600 ~/.ssh/id_rsa
           cat >> ~/.ssh/config <<'EOF'
           Host dokku-ssh.iphoting.cc
             ProxyCommand docker run --rm -i cloudflare/cloudflared:latest access ssh --hostname %h
+            IdentityFile ~/.ssh/id_rsa
             StrictHostKeyChecking no
+            ServerAliveInterval 30
+            ServerAliveCountMax 20
           EOF
-      - name: Push to dokku
-        uses: dokku/github-action@v1.4.0
-        with:
-          # specify `--force` as a flag for git pushes
-          git_push_flags: '--force'
-          git_remote_url: 'ssh://dokku@dokku-ssh.iphoting.cc/iphobot'
-          ssh_private_key: ${{ secrets.SSH_PRIVATE_KEY }}
+          git remote add dokku ssh://dokku@dokku-ssh.iphoting.cc/iphobot
+          git push dokku HEAD:master --force


### PR DESCRIPTION
## Summary

- Replaces direct SSH to `c.iphoting.cc:3022` with Cloudflare tunnel via `dokku-ssh.iphoting.cc`
- Uses `docker run cloudflare/cloudflared:latest` as SSH ProxyCommand — no install step needed
- `SSH_PRIVATE_KEY` secret unchanged

## Test plan

- [ ] Merge to `master` and verify the deploy workflow succeeds end-to-end
- [ ] Confirm port 3022 can be firewalled off after all 6 repos are merged

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mx3TtNcPLxofoGoc79QZ22)_